### PR TITLE
Meta, Route, Settings, Target entities escaped table names

### DIFF
--- a/src/Brabijan/SeoComponents/Entity/Meta.php
+++ b/src/Brabijan/SeoComponents/Entity/Meta.php
@@ -7,7 +7,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity()
- * @ORM\Table(name="seoMeta")
+ * @ORM\Table(name="`seoMeta`")
  * @property $id
  * @property $seoTitle
  * @property $seoKeywords

--- a/src/Brabijan/SeoComponents/Entity/Route.php
+++ b/src/Brabijan/SeoComponents/Entity/Route.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity()
- * @ORM\Table(name="seoRoute")
+ * @ORM\Table(name="`seoRoute`")
  * @property $id
  * @property $slug
  * @property boolean $oneWay

--- a/src/Brabijan/SeoComponents/Entity/Settings.php
+++ b/src/Brabijan/SeoComponents/Entity/Settings.php
@@ -7,7 +7,7 @@ use Kdyby\Doctrine\Entities\BaseEntity;
 
 /**
  * @ORM\Entity()
- * @ORM\Table(name="seoSettings")
+ * @ORM\Table(name="`seoSettings`")
  * @property $id
  * @property $name
  * @property $value

--- a/src/Brabijan/SeoComponents/Entity/Target.php
+++ b/src/Brabijan/SeoComponents/Entity/Target.php
@@ -8,7 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity()
- * @ORM\Table(name="seoTarget")
+ * @ORM\Table(name="`seoTarget`")
  * @property $id
  * @property $targetPresenter
  * @property $targetAction


### PR DESCRIPTION
check https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php#L2258-L2261 doctrine escapes everything escaped by ` with correct quotes